### PR TITLE
Publish package (with API KEY) + Yank package

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "my_cool_package"
-authors = ["my@joinme.com"]
-compiler_version = ">=0.18.0"
-version = "2.0.11"
-type = "lib"
-description = "This is a test package! Let's go! Changed!"
-keywords = ["utility", "tool"]

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "my_cool_package"
+authors = ["my@joinme.com"]
+compiler_version = ">=0.18.0"
+version = "2.0.8"
+type = "lib"
+description = "This is a test package! Let's go! Changed!"
+keywords = ["utility", "tool"]

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,7 +2,7 @@
 name = "my_cool_package"
 authors = ["my@joinme.com"]
 compiler_version = ">=0.18.0"
-version = "2.0.8"
+version = "2.0.11"
 type = "lib"
 description = "This is a test package! Let's go! Changed!"
 keywords = ["utility", "tool"]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Usage: `noir-libs --help`
 ## Features
 
 The following features are supported:
-- Add a package from the package repository to a project: `noir-libs add <package_name>@<package-version>`. 
+- **add** a package from the package repository to a project: `noir-libs add <package_name>@<package-version>`. 
   If no version is specified, the latest version will be fetched e.g. `noir-libs add aztec`
-- Remove a package from a project: `noir-libs remove <package_name>`
+- **remove** a package from a project: `noir-libs remove <package_name>`
+- **package** a Nargo project to a distributable tarball. Inside Noir project: `noir-libs package`
+- **publish** a Nargo package to public remote package registry. Inside Noir project: `noir-libs publish`
 
 ### Supported packages
 

--- a/noir-libs/src/api/api.rs
+++ b/noir-libs/src/api/api.rs
@@ -11,8 +11,8 @@ pub fn get_latest_package_version_api(package_name: &str) -> Result<String, Stri
     get_latest_package_version(get_latest_package_version_url(package_name))
 }
 
-pub fn publish_package_api(tarball_path: &PackagedTarball) -> anyhow::Result<String> {
-    publish_package(tarball_path, get_publish_package_url(tarball_path.name.as_str(), tarball_path.version.as_str()))
+pub fn publish_package_api(tarball_path: &PackagedTarball, api_key: String) -> anyhow::Result<String> {
+    publish_package(tarball_path, get_publish_package_url(tarball_path.name.as_str(), tarball_path.version.as_str()), api_key)
 }
 
 /// Retrieves the URL where to retrieve a package

--- a/noir-libs/src/api/api.rs
+++ b/noir-libs/src/api/api.rs
@@ -1,4 +1,4 @@
-use crate::api::network::{download_package, get_latest_package_version, publish_package};
+use crate::api::network::{download_package, get_latest_package_version, publish_package, yank_package};
 use crate::config::REGISTRY_URL;
 use std::path::Path;
 use crate::ops::package::package::PackagedTarball;
@@ -12,7 +12,11 @@ pub fn get_latest_package_version_api(package_name: &str) -> Result<String, Stri
 }
 
 pub fn publish_package_api(tarball_path: &PackagedTarball, api_key: String) -> anyhow::Result<String> {
-    publish_package(tarball_path, get_publish_package_url(tarball_path.name.as_str(), tarball_path.version.as_str()), api_key)
+    publish_package(tarball_path, api_key, get_publish_package_url(tarball_path.name.as_str(), tarball_path.version.as_str()))
+}
+
+pub fn yank_package_api(package_name: &str, version: &str, api_key: String) -> anyhow::Result<String> {
+    yank_package(package_name, version, api_key, get_yank_package_url(package_name, version))
 }
 
 /// Retrieves the URL where to retrieve a package
@@ -33,3 +37,8 @@ fn get_publish_package_url(package_name: &str, version: &str) -> String {
     format!("{}/packages/{}/{}/publish", REGISTRY_URL, &package_name, &version)
 }
 
+/// Retrieves the URL for yanking a package version in remote registry
+/// Example: http://localhost:3001/api/v1/packages/my_cool_package/0.1.0/yank
+fn get_yank_package_url(package_name: &str, version: &str) -> String {
+    format!("{}/packages/{}/{}/yank", REGISTRY_URL, &package_name, &version)
+}

--- a/noir-libs/src/api/api.rs
+++ b/noir-libs/src/api/api.rs
@@ -15,7 +15,7 @@ pub fn publish_package_api(tarball_path: &PackagedTarball, api_key: String) -> a
     publish_package(tarball_path, api_key, get_publish_package_url(tarball_path.name.as_str(), tarball_path.version.as_str()))
 }
 
-pub fn yank_package_api(package_name: &str, version: &str, api_key: String) -> anyhow::Result<String> {
+pub fn yank_package_api(package_name: &str, version: &str, api_key: String) -> anyhow::Result<()> {
     yank_package(package_name, version, api_key, get_yank_package_url(package_name, version))
 }
 

--- a/noir-libs/src/api/network.rs
+++ b/noir-libs/src/api/network.rs
@@ -84,7 +84,7 @@ pub fn get_latest_package_version(url: String) -> Result<String, String> {
 ///
 /// * `packaged_tarball` - a GZIP compressed tarball of the package to be published.
 /// * `api_key` - the API key to authenticate the user generated in the remote registry.
-/// * `api_key` - A string containing the URL to publish a package.
+/// * `url` - A string containing the URL to publish a package.
 ///
 /// # Returns
 ///
@@ -150,7 +150,7 @@ fn get_error_message_from_response(response: reqwest::blocking::Response) -> Str
     }
 }
 
-pub fn yank_package(name: &str, version: &str, api_key: String, url: String) -> anyhow::Result<String> {
+pub fn yank_package(name: &str, version: &str, api_key: String, url: String) -> anyhow::Result<()> {
     let client = reqwest::blocking::Client::new();
     match client
         .put(&url)
@@ -158,7 +158,7 @@ pub fn yank_package(name: &str, version: &str, api_key: String, url: String) -> 
         .send() {
             Ok(response) => {
                 if response.status().is_success() {
-                    Ok(formatdoc! { "Successfully yanked {} {} package version.", &name, &version })
+                    Ok(())
                 } else if response.status().is_client_error() {
                     let err_message = get_error_message_from_response(response);
                     bail!("Failed to yank a package: {} {}. Error message: {}", &name, &version, &err_message)

--- a/noir-libs/src/config.rs
+++ b/noir-libs/src/config.rs
@@ -8,4 +8,4 @@ pub const REGISTRY_HOME_URL: &str = "http://localhost:3000";
 // Packaged projects (packages) are generated in this folder e.g. target/package/my_cool_package_0.1.1
 pub const PACKAGING_OUTPUT_FOLDER_PATH: &str = "target/package";
 // The name of ENV variable that contains the API key - required for package publishing
-pub const API_KEY_ENV_VAR_NAME: &str = "API_KEY";
+pub const API_KEY_ENV_VAR_NAME: &str = "NOIR_LIBS_API_KEY";

--- a/noir-libs/src/config.rs
+++ b/noir-libs/src/config.rs
@@ -7,3 +7,5 @@ pub const REGISTRY_URL: &str = "http://localhost:3001/api/v1";
 pub const REGISTRY_HOME_URL: &str = "http://localhost:3000";
 // Packaged projects (packages) are generated in this folder e.g. target/package/my_cool_package_0.1.1
 pub const PACKAGING_OUTPUT_FOLDER_PATH: &str = "target/package";
+// The name of ENV variable that contains the API key - required for package publishing
+pub const API_KEY_ENV_VAR_NAME: &str = "API_KEY";

--- a/noir-libs/src/main.rs
+++ b/noir-libs/src/main.rs
@@ -119,7 +119,10 @@ fn main() {
             match split_package_to_name_and_version_with_validation(package) {
                 Ok((package_name, version)) => {
                     match yank(package_name, version) {
-                        Ok(result_message) => println!("{}", result_message.green().bold()),
+                        Ok(()) => {
+                            let result_message = formatdoc! { "Successfully yanked {} {} package version.", &package_name, &version };
+                            println!("{}", result_message.green().bold())
+                        },
                         Err(e) => { println!("{}", format!("Error: {}", e).red().bold()); }
                     }
                 },

--- a/noir-libs/src/main.rs
+++ b/noir-libs/src/main.rs
@@ -139,7 +139,7 @@ fn split_package_to_name_and_version_with_validation(package: &String) -> anyhow
     let parts: Vec<&str> = package.split('@').collect();
     let version = if parts.len() == 2 {
         let version = parts[1];
-        if let Err(e) = semver::Version::parse(version) {
+        if let Err(_e) = semver::Version::parse(version) {
             bail!("Package version {} is incorrect. Assure correct semantic versioning value.", version);
         }
         version

--- a/noir-libs/src/manifest.rs
+++ b/noir-libs/src/manifest.rs
@@ -44,7 +44,7 @@ impl fmt::Display for PackageType {
 }
 
 pub fn read_manifest(project_dir: &PathBuf) -> Result<Manifest> {
-    let manifest = try_find_manifest(&project_dir).with_context(|| format!("Unable to find {} manifest file. Please verify you are in the correct directory.", &MANIFEST_FILE_NAME))?;
+    let manifest = get_manifest(&project_dir).with_context(|| format!("Unable to find {} manifest file. Please verify you are in the correct directory.", &MANIFEST_FILE_NAME))?;
     let content = std::fs::read_to_string(manifest.clone()).with_context(|| format!("Cannot read {} manifest file. File {} was found but cannot be read.", &MANIFEST_FILE_NAME, manifest.to_str().unwrap()))?;
     let doc: toml::Value  = toml::from_str(&content).with_context(|| format!("{} manifest file is invalid TOML.", manifest.to_str().unwrap()))?;
     let manifest: Manifest = doc.try_into().with_context(|| format!("Failed to parse {} manifest file. Assure file has all required properties.", &MANIFEST_FILE_NAME))?;
@@ -142,6 +142,24 @@ fn try_find_manifest(start_dir: &Path) -> Option<PathBuf> {
         root = path.parent();
     }
     None
+}
+
+/// Reads TOML manifest file in the given directory.
+///
+/// # Arguments
+///
+/// * `dir` - The dir where to read.
+///
+/// # Returns
+///
+/// An `Option<PathBuf>` that contains the path to the manifest file if found, or `None` if not found.
+fn get_manifest(dir: &Path) -> Option<PathBuf> {
+    let manifest = dir.join(MANIFEST_FILE_NAME);
+    if manifest.is_file() {
+        Some(manifest)
+    } else {
+        None
+    }
 }
 
 fn extract_version_from_path(path: &str) -> Option<String> {

--- a/noir-libs/src/ops/mod.rs
+++ b/noir-libs/src/ops/mod.rs
@@ -2,3 +2,4 @@ pub mod add;
 pub mod remove;
 pub mod package;
 pub mod publish;
+pub mod yank;

--- a/noir-libs/src/ops/package/name_validator.rs
+++ b/noir-libs/src/ops/package/name_validator.rs
@@ -1,132 +1,13 @@
 use anyhow::bail;
 use crate::config::MANIFEST_FILE_NAME;
 
-const RESERVED_NAMES: &[&str] = &[
-    "nul", "con", "prn", "aux", "clock$", "com1", "com2", "com3", "com4",
-    "com5", "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4",
-    "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"
-];
-
-// Name validation is inspired by crates.io specification https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field
-// Rules:
-// - maximum of 64 characters of length and not empty
-// - only alphanumeric characters are allowed, except for special characters: "-" and "_"
-// - cannot start with special character
-// - can contain only single special characters between alphanumeric characters (e.g. no "--" or "__")
-// - do not use special Windows names such as “nul”
-pub fn validate_name(name: &str) -> anyhow::Result<()> {
+// Name validation is done on backend side
+// Here we perform very basic validation
+pub fn validate_name_is_not_empty(name: &str) -> anyhow::Result<()> {
     // Must not be empty
-    if name.is_empty() {
+    if name.trim().is_empty() {
         bail! {"package name {} in {} name is invalid. It cannot be empty.", &name, MANIFEST_FILE_NAME };
     }
 
-    // Must be at most 64 characters
-    if name.len() > 64 {
-        bail! {"package name {} in {} name is invalid. It must be maximum of 64 characters long.", &name, MANIFEST_FILE_NAME };
-    }
-
-    // First character must be alphanumeric
-    let mut chars = name.chars();
-    if let Some(first_char) = chars.next() {
-        if !first_char.is_ascii_alphanumeric() {
-            bail! {"package name {} in {} name is invalid. First character must be alphanumeric.", &name, MANIFEST_FILE_NAME };
-        }
-    }
-
-    // Last character must be alphanumeric
-    if let Some(last_char) = name.chars().last() {
-        if !last_char.is_ascii_alphanumeric() {
-            bail! {"package name {} in {} name is invalid. Last character must be alphanumeric.", &name, MANIFEST_FILE_NAME };
-        }
-    }
-
-    // Must contain only alphanumeric characters, `_`, or `-`
-    for c in name.chars() {
-        if !c.is_ascii_alphanumeric() && c != '_' && c != '-' {
-            bail! {"package name {} in {} name is invalid. Can contain only alphanumeric characters, '-' or '_'.", &name, MANIFEST_FILE_NAME };
-        }
-    }
-
-    // Can contain only single special characters between alphanumeric characters
-    let special_characters_correct = only_contains_single_special_characters(&name);
-    if !special_characters_correct {
-        bail! {"package name {} in {} name is invalid. Can contain only alphanumeric characters, '-' or '_'.", &name, MANIFEST_FILE_NAME };
-    }
-
-    // Must not be a reserved name (case insensitive)
-    let lowercase_name = name.to_ascii_lowercase();
-    if RESERVED_NAMES.contains(&lowercase_name.as_str()) {
-        bail! {"package name {} in {} name is invalid. It is reserved value and cannot be used as name.", &name, MANIFEST_FILE_NAME };
-    }
-
     Ok(())
-}
-
-fn only_contains_single_special_characters(name: &str) -> bool {
-    let mut chars = name.chars().peekable();
-    let mut prev_was_separator = false;
-    let mut is_correct = true;
-    while let Some(c) = chars.next() {
-        if c == '-' || c == '_' {
-            if prev_was_separator {
-                is_correct = false;
-                break;
-            }
-            prev_was_separator = true;
-        } else if c.is_ascii_alphanumeric() {
-            prev_was_separator = false;
-        } else {
-            is_correct = false;
-            break;
-        }
-    }
-    is_correct
-}
-#[cfg(test)]
-mod tests {
-    use crate::ops::package::name_validator::validate_name;
-
-    #[test]
-    fn test_validate_name() -> anyhow::Result<()> {
-        let long_name = "a".repeat(64);
-
-        let valid_names = [
-            "serde",
-            "serde_json",
-            "my-crate",
-            "some_package_2",
-            "hello_world",
-            "valid123",
-            "valid-name-123",
-            long_name.as_str(),
-        ];
-
-        for name in valid_names.iter() {
-            assert!(
-                validate_name(name).is_ok(),
-                "Expected '{}' to be valid, but it was rejected",
-                name
-            );
-        }
-
-        let invalid_names = [
-            "nul", "con", "prn", "lpt1", // Windows reserved names
-            "-serde", "_serde",          // Cannot start with `-` or `_`
-            "serde-", "serde_",          // Cannot end with `-` or `_`
-            "serde--json", "serde__json", // Double `--` or `__` not allowed
-            "my--cool-package", "my_cool__package", // Double `--` or `__` not allowed
-            "some@crate", "crate!", "crate.lib",      // Invalid characters
-            "this_is_a_really_long_package_name_that_exceeds_sixty_four_characters", // Too long
-        ];
-
-        for name in invalid_names.iter() {
-            assert!(
-                validate_name(name).is_err(),
-                "Expected '{}' to be invalid, but it was accepted",
-                name
-            );
-        }
-
-        Ok(())
-    }
 }

--- a/noir-libs/src/ops/package/package.rs
+++ b/noir-libs/src/ops/package/package.rs
@@ -15,7 +15,6 @@ pub struct PackagedTarball {
 
 pub fn package(manifest_folder: &PathBuf, dst_folder: &PathBuf) -> Result<PackagedTarball> {
     let manifest: Manifest = read_manifest(&manifest_folder)?;
-
     verify_package_type_is_lib(&manifest)?;
     let version = verify_and_get_version(&manifest)?;
     let package_name = verify_and_get_package_name(&manifest)?;
@@ -97,6 +96,7 @@ fn verify_and_get_version(manifest: &Manifest) -> Result<String> {
 fn verify_and_get_package_name(manifest: &Manifest) -> Result<&String> {
     match &manifest.package.name {
         Some(name) => {
+            println!("hehehe mam anzwe: {:?}", name);
             validate_name(name)?;
             Ok(name)
         }

--- a/noir-libs/src/ops/package/package.rs
+++ b/noir-libs/src/ops/package/package.rs
@@ -101,7 +101,7 @@ fn verify_and_get_package_name(manifest: &Manifest) -> Result<&String> {
         }
         None => {
             bail!(formatdoc! {
-                "package name in {} file is not set. Assure correct semantic versioning value. Example:
+                "package name in {} file is not set. Please provide valid package name. Example:
 
                  [package]
                  name = \"my_example_package\"", &MANIFEST_FILE_NAME }

--- a/noir-libs/src/ops/package/package.rs
+++ b/noir-libs/src/ops/package/package.rs
@@ -67,7 +67,7 @@ fn verify_package_type_is_lib(manifest: &Manifest) -> Result<()> {
     }
 }
 
-fn verify_and_get_version(manifest: &Manifest) -> Result<String> {
+pub fn verify_and_get_version(manifest: &Manifest) -> Result<String> {
     match &manifest.package.version {
         Some(version) => {
             match semver::Version::parse(version) {
@@ -93,7 +93,7 @@ fn verify_and_get_version(manifest: &Manifest) -> Result<String> {
     }
 }
 
-fn verify_and_get_package_name(manifest: &Manifest) -> Result<&String> {
+pub fn verify_and_get_package_name(manifest: &Manifest) -> Result<&String> {
     match &manifest.package.name {
         Some(name) => {
             validate_name_is_not_empty(name)?;

--- a/noir-libs/src/ops/package/package.rs
+++ b/noir-libs/src/ops/package/package.rs
@@ -5,7 +5,7 @@ use crate::tar::create_tar_gz;
 use anyhow::{bail, Result};
 use indoc::formatdoc;
 use std::path::PathBuf;
-use crate::ops::package::name_validator::validate_name;
+use crate::ops::package::name_validator::validate_name_is_not_empty;
 
 pub struct PackagedTarball {
     pub tarball_path: String,
@@ -96,8 +96,7 @@ fn verify_and_get_version(manifest: &Manifest) -> Result<String> {
 fn verify_and_get_package_name(manifest: &Manifest) -> Result<&String> {
     match &manifest.package.name {
         Some(name) => {
-            println!("hehehe mam anzwe: {:?}", name);
-            validate_name(name)?;
+            validate_name_is_not_empty(name)?;
             Ok(name)
         }
         None => {

--- a/noir-libs/src/ops/publish.rs
+++ b/noir-libs/src/ops/publish.rs
@@ -1,8 +1,10 @@
 use crate::api::api::publish_package_api;
 use crate::config::{API_KEY_ENV_VAR_NAME, PACKAGING_OUTPUT_FOLDER_PATH, REGISTRY_HOME_URL};
-use crate::ops::package::package::package;
+use crate::manifest::{read_manifest, Manifest};
+use crate::ops::package::package::{verify_and_get_package_name, verify_and_get_version, PackagedTarball};
 use anyhow::{bail, Result};
 use indoc::formatdoc;
+use std::path::PathBuf;
 
 pub fn publish() -> Result<String> {
     let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
@@ -19,10 +21,27 @@ pub fn publish() -> Result<String> {
             );
         }
     };
-    let current_dir = std::env::current_dir()?;
-    let output_folder_path = &current_dir.join(PACKAGING_OUTPUT_FOLDER_PATH);
 
-    let tarball_path = package(&current_dir, &output_folder_path)?;
+    let tarball_path = verify_tarball_existence()?;
     let result_message = publish_package_api(&tarball_path, api_key)?;
     Ok(result_message)
+}
+
+fn verify_tarball_existence() -> Result<PackagedTarball> {
+    let current_dir = std::env::current_dir()?;
+    let manifest: Manifest = read_manifest(&current_dir)?;
+    let output_folder_path = &current_dir.join(PACKAGING_OUTPUT_FOLDER_PATH);
+    let version = verify_and_get_version(&manifest)?;
+    let package_name = verify_and_get_package_name(&manifest)?;
+    let package = format!("{}_{}", &package_name, &version);
+    let tarball_path = output_folder_path.join(&package).join(format!("{}.tar.gz", &package));
+    println!("Tarball path: {}", tarball_path.display());
+    if !tarball_path.exists() {
+        bail!("Package tarball does not exists. Please run \"noir-libs package\" first.");
+    }
+    Ok(PackagedTarball {
+        tarball_path: tarball_path.to_str().unwrap().to_string(),
+        name: package_name.to_string(),
+        version: version.to_string(),
+    })
 }

--- a/noir-libs/src/ops/publish.rs
+++ b/noir-libs/src/ops/publish.rs
@@ -4,7 +4,6 @@ use crate::manifest::{read_manifest, Manifest};
 use crate::ops::package::package::{verify_and_get_package_name, verify_and_get_version, PackagedTarball};
 use anyhow::{bail, Result};
 use indoc::formatdoc;
-use std::path::PathBuf;
 
 pub fn publish() -> Result<String> {
     let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
@@ -16,8 +15,8 @@ pub fn publish() -> Result<String> {
                  Please generate an API KEY with \"publish\" scope  key at {}.
 
                  If you already have an API KEY, please export it before running publish command:
-                 export API_KEY=<your api key>
-                 ", format!("{}/dashboard", &REGISTRY_HOME_URL) }
+                 export {}=<your api key>
+                 ", format!("{}/dashboard", &REGISTRY_HOME_URL), &API_KEY_ENV_VAR_NAME }
             );
         }
     };

--- a/noir-libs/src/ops/publish.rs
+++ b/noir-libs/src/ops/publish.rs
@@ -7,7 +7,7 @@ use indoc::formatdoc;
 pub fn publish() -> Result<String> {
     let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
         Ok(api_key) => api_key,
-        Err(e) => {
+        Err(_e) => {
             bail!(formatdoc! {
                 "Cannot publish a package. API KEY env variable not found.
 

--- a/noir-libs/src/ops/publish.rs
+++ b/noir-libs/src/ops/publish.rs
@@ -1,13 +1,28 @@
 use crate::api::api::publish_package_api;
-use crate::config::PACKAGING_OUTPUT_FOLDER_PATH;
+use crate::config::{API_KEY_ENV_VAR_NAME, PACKAGING_OUTPUT_FOLDER_PATH, REGISTRY_HOME_URL};
 use crate::ops::package::package::package;
-use anyhow::Result;
+use anyhow::{bail, Result};
+use indoc::formatdoc;
 
 pub fn publish() -> Result<String> {
+    let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
+        Ok(api_key) => api_key,
+        Err(e) => {
+            bail!(formatdoc! {
+                "Cannot publish a package. API KEY env variable not found.
+
+                 Please generate an API KEY with \"publish\" scope  key at {}.
+
+                 If you already have an API KEY, please export it before running publish command:
+                 export API_KEY=<your api key>
+                 ", format!("{}/dashboard", &REGISTRY_HOME_URL) }
+            );
+        }
+    };
     let current_dir = std::env::current_dir()?;
     let output_folder_path = &current_dir.join(PACKAGING_OUTPUT_FOLDER_PATH);
 
     let tarball_path = package(&current_dir, &output_folder_path)?;
-    let result_message = publish_package_api(&tarball_path)?;
+    let result_message = publish_package_api(&tarball_path, api_key)?;
     Ok(result_message)
 }

--- a/noir-libs/src/ops/yank.rs
+++ b/noir-libs/src/ops/yank.rs
@@ -6,7 +6,7 @@ use crate::config::{API_KEY_ENV_VAR_NAME, REGISTRY_HOME_URL};
 pub fn yank(package_name: &str, version: &str) -> anyhow::Result<String> {
     let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
         Ok(api_key) => api_key,
-        Err(e) => {
+        Err(_e) => {
             bail!(formatdoc! {
                 "Cannot yank a package. API KEY env variable not found.
 

--- a/noir-libs/src/ops/yank.rs
+++ b/noir-libs/src/ops/yank.rs
@@ -1,0 +1,22 @@
+use anyhow::bail;
+use indoc::formatdoc;
+use crate::api::api::yank_package_api;
+use crate::config::{API_KEY_ENV_VAR_NAME, REGISTRY_HOME_URL};
+
+pub fn yank(package_name: &str, version: &str) -> anyhow::Result<String> {
+    let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
+        Ok(api_key) => api_key,
+        Err(e) => {
+            bail!(formatdoc! {
+                "Cannot yank a package. API KEY env variable not found.
+
+                 Please generate an API KEY with \"yank\" scope  key at {}.
+
+                 If you already have an API KEY, please export it before running yank command:
+                 export API_KEY=<your api key>
+                 ", format!("{}/dashboard", &REGISTRY_HOME_URL) }
+            );
+        }
+    };
+    yank_package_api(package_name, version, api_key)
+}

--- a/noir-libs/src/ops/yank.rs
+++ b/noir-libs/src/ops/yank.rs
@@ -3,7 +3,7 @@ use indoc::formatdoc;
 use crate::api::api::yank_package_api;
 use crate::config::{API_KEY_ENV_VAR_NAME, REGISTRY_HOME_URL};
 
-pub fn yank(package_name: &str, version: &str) -> anyhow::Result<String> {
+pub fn yank(package_name: &str, version: &str) -> anyhow::Result<()> {
     let api_key = match std::env::var(&API_KEY_ENV_VAR_NAME) {
         Ok(api_key) => api_key,
         Err(_e) => {
@@ -13,8 +13,8 @@ pub fn yank(package_name: &str, version: &str) -> anyhow::Result<String> {
                  Please generate an API KEY with \"yank\" scope  key at {}.
 
                  If you already have an API KEY, please export it before running yank command:
-                 export API_KEY=<your api key>
-                 ", format!("{}/dashboard", &REGISTRY_HOME_URL) }
+                 export {}=<your api key>
+                 ", format!("{}/dashboard", &REGISTRY_HOME_URL), &API_KEY_ENV_VAR_NAME }
             );
         }
     };

--- a/noir-libs/src/path.rs
+++ b/noir-libs/src/path.rs
@@ -1,7 +1,7 @@
 use directories::ProjectDirs;
 use std::path::PathBuf;
 
-use crate::config::{COMPANY_NAME, COMPANY_TLD, REGISTRY_URL};
+use crate::config::{COMPANY_NAME, COMPANY_TLD};
 
 /// Gets a cache directory, based on operation system
 /// Linux: /home/user/.cache/noir-libs/
@@ -56,5 +56,31 @@ mod tests {
         let result = get_cache_dir();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), cache_dir);
+    }
+
+    #[test]
+    fn test_get_full_package_name() {
+        let result = get_full_package_name("aztec", "0.67.0");
+        assert_eq!(result, "aztec_0.67.0");
+    }
+
+    #[test]
+    fn test_get_package_filename() {
+        let result = get_package_filename("value_note", "0.67.0");
+        assert_eq!(result, "value_note_0.67.0.archive");
+    }
+
+    #[test]
+    fn test_get_cache_storage() {
+        let cache_root = PathBuf::from("/home/user/.cache/noir-libs");
+        let result = get_cache_storage(cache_root.clone(), "value_note", "0.67.0");
+        assert_eq!(result.to_str().unwrap(), "/home/user/.cache/noir-libs/value_note_0.67.0.archive");
+    }
+
+    #[test]
+    fn test_get_package_dir() {
+        let cache_root = PathBuf::from("/home/user/.cache/noir-libs");
+        let result = get_package_dir(cache_root.clone(), "value_note", "0.67.0");
+        assert_eq!(result.to_str().unwrap(), "/home/user/.cache/noir-libs/value_note/0.67.0");
     }
 }


### PR DESCRIPTION
This is the 2nd (and final) part of Milestone 3 "package and publish" feature set. This PR is a merge to previous (https://github.com/walnuthq/noir-libs/pull/3) changes branch. After this PR is reviewed, it will be both merged to master and published.

Changes in this PR:
- `publish` command now requires exporting API_KEY generated in noir-libs.org. User cannot publish packages without being authorized (with no api key). 
- added `yank` command - allows package to be yanked ("removed" from registry)
- package name validator is simplified - complex validation is now done only on backend. In case of name being incorrect, CLI will get backend error on publishing.