### PR TITLE
Dependencies path relative to a project

### DIFF
--- a/noir-libs/src/config.rs
+++ b/noir-libs/src/config.rs
@@ -1,6 +1,5 @@
+pub const DEPENDENCIES_FOLDER_NAME: &str = ".noir-libs-dependencies";
 pub const MANIFEST_FILE_NAME: &str = "Nargo.toml";
-pub const COMPANY_NAME: &str = "walnut";
-pub const COMPANY_TLD: &str = "dev";
 pub const REGISTRY_URL: &str = "https://api.noir-libs.org/api/v1";
 // pub const REGISTRY_URL: &str = "http://localhost:3001/api/v1";
 pub const REGISTRY_HOME_URL: &str = "https://noir-libs.org";

--- a/noir-libs/src/config.rs
+++ b/noir-libs/src/config.rs
@@ -1,4 +1,4 @@
-pub const DEPENDENCIES_FOLDER_NAME: &str = ".noir-libs-dependencies";
+pub const DEPENDENCIES_FOLDER_NAME: &str = ".noir-libs-deps";
 pub const MANIFEST_FILE_NAME: &str = "Nargo.toml";
 pub const REGISTRY_URL: &str = "https://api.noir-libs.org/api/v1";
 // pub const REGISTRY_URL: &str = "http://localhost:3001/api/v1";

--- a/noir-libs/src/filesystem.rs
+++ b/noir-libs/src/filesystem.rs
@@ -4,12 +4,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::path::get_cache_dir;
 use ignore::WalkBuilder;
+use crate::config::DEPENDENCIES_FOLDER_NAME;
 
-pub fn prepare_cache_dir() -> PathBuf {
-    let cache_dir = get_cache_dir().expect("Could not determine cache directory");
-    ensure_dir(&cache_dir).expect("Failed to setup cache directory");
+pub fn prepare_cache_dir(manifest_dir: &PathBuf) -> PathBuf {
+    let cache_dir = manifest_dir.join(&DEPENDENCIES_FOLDER_NAME);
+    ensure_dir(&cache_dir).expect("Failed to setup dependencies cache directory");
     cache_dir
 }
 

--- a/noir-libs/src/main.rs
+++ b/noir-libs/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use colored::Colorize;
 use indoc::formatdoc;
 use noir_libs::config::PACKAGING_OUTPUT_FOLDER_PATH;
@@ -9,6 +9,7 @@ use noir_libs::ops::publish::publish;
 use noir_libs::ops::remove;
 use noir_libs::ops::yank::yank;
 use std::io;
+use noir_libs::ops::fetch::fetch;
 
 /// A CLI package manager for Noir | noir-libs.org
 #[derive(Parser)]
@@ -46,7 +47,11 @@ enum Commands {
     Yank {
         /// Package to yank in the format "package@version"
         package: String
-    }
+    },
+
+    /// Download all dependencies for a project
+    Fetch {
+    },
 }
 
 fn main() {
@@ -89,7 +94,7 @@ fn main() {
             }
             std::process::exit(1);
         }
-        Commands::Package {force} => {
+        Commands::Package { force } => {
             if !force {
                 let info = formatdoc! {
                     "This command packages your project to a tarball which later can be published to a remote registry.
@@ -129,6 +134,16 @@ fn main() {
                 Err(e) => { println!("{}", format!("Error: {}", e).red().bold()); }
             }
             std::process::exit(1);
+        },
+        Commands::Fetch {} => {
+            match fetch() {
+                Ok(_) => {
+                    println!("{}", "Downloaded all project dependencies.".green().bold());
+                }
+                Err(e) => {
+                    println!("{}", format!("Error: {}", e).red().bold());
+                }
+            }
         }
     }
 }

--- a/noir-libs/src/manifest.rs
+++ b/noir-libs/src/manifest.rs
@@ -67,9 +67,8 @@ pub fn read_manifest(project_dir: &PathBuf) -> Result<Manifest> {
 ///
 /// This function will panic if the manifest file cannot be found, if the file cannot be read,
 /// or if the content is not valid TOML.
-pub fn write_package_dep(project_dir: PathBuf, package_name: &str, path: &str) -> PathBuf {
-    let manifest = try_find_manifest(&project_dir).expect(format!("Unable to find {} manifest file", &MANIFEST_FILE_NAME).as_str());
-    let content = std::fs::read_to_string(manifest.clone()).expect(format!("Cannot read {} manifest file", &MANIFEST_FILE_NAME).as_str());
+pub fn write_package_dep(manifest_path: &PathBuf, package_name: &str, path: &str) -> PathBuf {
+    let content = std::fs::read_to_string(manifest_path.clone()).expect(format!("Cannot read {} manifest file", &MANIFEST_FILE_NAME).as_str());
     let mut doc = content.parse::<DocumentMut>().expect("Invalid TOML");
 
     // Ensure the "dependencies" table exists
@@ -82,9 +81,9 @@ pub fn write_package_dep(project_dir: PathBuf, package_name: &str, path: &str) -
     // Assign to the dependencies table
     dependencies[package_name] = toml_edit::Item::Value(toml_edit::Value::InlineTable(table));
 
-    std::fs::write(manifest.clone(), doc.to_string()).expect("Cannot write file");
+    std::fs::write(manifest_path.clone(), doc.to_string()).expect("Cannot write file");
 
-    manifest
+    manifest_path.clone()
 }
 
 /// Retrieves the dependencies and their versions from the specified TOML manifest file.
@@ -132,7 +131,7 @@ pub fn get_dependencies(manifest: PathBuf) -> Vec<(String, String)> {
 /// # Returns
 ///
 /// An `Option<PathBuf>` that contains the path to the manifest file if found, or `None` if not found.
-fn try_find_manifest(start_dir: &Path) -> Option<PathBuf> {
+pub fn try_find_manifest(start_dir: &Path) -> Option<PathBuf> {
     let mut root = Some(start_dir);
     while let Some(path) = root {
         let manifest = path.join(MANIFEST_FILE_NAME);
@@ -204,6 +203,7 @@ pub fn remove_package(dir: PathBuf, package_name: &str) {
 mod tests {
     use super::*;
     use std::fs;
+    use crate::config::DEPENDENCIES_FOLDER_NAME;
 
     #[test]
     fn test_write_package_dep() {
@@ -216,13 +216,13 @@ mod tests {
 
         // Call the function to test
         let package_name = "my_package";
-        let path = "../../my_package/0.1.0";
-        let result = write_package_dep(project_dir.clone(), package_name, path);
+        let path = format!("{}/my_package/0.1.0", DEPENDENCIES_FOLDER_NAME);
+        let result = write_package_dep(&manifest_path, package_name, path.as_str());
 
         // Verify that the manifest file was updated correctly
         let content = fs::read_to_string(result).unwrap();
         assert!(content.contains("my_package"));
-        assert!(content.contains("path = \"../../my_package/0.1.0\""));
+        assert!(content.contains(format!("path = \"{}\"", path).as_str()));
 
         // Cleanup
         temp_dir.close().unwrap();
@@ -240,7 +240,7 @@ mod tests {
         // Call the function to test
         let package_name = "my_package";
         let path = "../../my_package/0.1.0";
-        let result = write_package_dep(project_dir.clone(), package_name, path);
+        let result = write_package_dep(&manifest_path, package_name, path);
 
         // Verify that the manifest file was updated correctly
         let content = fs::read_to_string(result).unwrap();

--- a/noir-libs/src/manifest.rs
+++ b/noir-libs/src/manifest.rs
@@ -48,6 +48,8 @@ pub enum PackageType {
     Library,
     #[serde(rename = "contract")]
     Contract,
+    #[serde(rename = "bin")]
+    Binary,
 }
 
 impl fmt::Display for PackageType {
@@ -55,6 +57,7 @@ impl fmt::Display for PackageType {
         match self {
             PackageType::Library => write!(f, "lib"),
             PackageType::Contract => write!(f, "contract"),
+            PackageType::Binary => write!(f, "bin"),
         }
     }
 }

--- a/noir-libs/src/manifest.rs
+++ b/noir-libs/src/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::fmt;
@@ -9,6 +10,7 @@ use crate::config::MANIFEST_FILE_NAME;
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
     pub package: Package,
+    pub dependencies: HashMap<String, Dependency>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -25,6 +27,20 @@ pub struct Package {
     pub documentation: Option<String>,
     pub repository: Option<String>,
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Dependency {
+    Git {
+        git: String,
+        tag: Option<String>,
+        directory: Option<String>,
+    },
+    Path {
+        path: String,
+    },
+}
+
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub enum PackageType {

--- a/noir-libs/src/ops/add.rs
+++ b/noir-libs/src/ops/add.rs
@@ -25,7 +25,7 @@ pub fn add(package_name: &str, version: &str) -> Result<String, String> {
     Ok(used_version)
 }
 
-fn store_package(
+pub fn store_package(
     cache_root: PathBuf,
     package_name: &str,
     version: &str,

--- a/noir-libs/src/ops/fetch.rs
+++ b/noir-libs/src/ops/fetch.rs
@@ -17,7 +17,6 @@ pub fn fetch() -> anyhow::Result<()> {
         match dependency {
             Dependency::Path { path } => {
                 let path = Path::new(path.as_str());
-                // Get the last two components of the path
                 let version = path.file_name().expect("Path is incorrect")
                     .to_str().expect("Path file name is not valid UTF-8");
                 let package_name = path.parent().expect("Path is incorrect").file_name().expect("Path is incorrect")

--- a/noir-libs/src/ops/fetch.rs
+++ b/noir-libs/src/ops/fetch.rs
@@ -1,0 +1,34 @@
+use std::path::Path;
+use colored::Colorize;
+use crate::config::MANIFEST_FILE_NAME;
+use crate::filesystem::prepare_cache_dir;
+use crate::manifest::{read_manifest, Dependency, Manifest};
+
+pub fn fetch() -> anyhow::Result<()> {
+    let current_dir = std::env::current_dir()?;
+    let manifest_path = crate::manifest::try_find_manifest(&current_dir).expect(format!("Unable to find {} manifest file", &MANIFEST_FILE_NAME).as_str());
+    let manifest: Manifest = read_manifest(&current_dir)?;
+    let manifest_dir = Path::new(&manifest_path)
+        .parent()
+        .expect("Failed to get manifest parent directory");
+    let cache_root = prepare_cache_dir(&manifest_dir.to_path_buf());
+
+    for dependency in manifest.dependencies.values() {
+        match dependency {
+            Dependency::Path { path } => {
+                let path = Path::new(path.as_str());
+                // Get the last two components of the path
+                let version = path.file_name().expect("Path is incorrect")
+                    .to_str().expect("Path file name is not valid UTF-8");
+                let package_name = path.parent().expect("Path is incorrect").file_name().expect("Path is incorrect")
+                    .to_str().expect("Path file name is not valid UTF-8");
+                if let Err(e) = crate::ops::add::store_package(cache_root.clone(), package_name, &version) {
+                    println!("{}", format!("Fetching dependency {}@{} failed: {}", package_name, version, e).red().bold());
+                }
+            },
+            Dependency::Git { .. } => {}
+        }
+    }
+
+    Ok(())
+}

--- a/noir-libs/src/ops/mod.rs
+++ b/noir-libs/src/ops/mod.rs
@@ -3,3 +3,4 @@ pub mod remove;
 pub mod package;
 pub mod publish;
 pub mod yank;
+pub mod fetch;

--- a/noir-libs/src/ops/package/package.rs
+++ b/noir-libs/src/ops/package/package.rs
@@ -1,4 +1,4 @@
-use crate::config::MANIFEST_FILE_NAME;
+use crate::config::{DEPENDENCIES_FOLDER_NAME, MANIFEST_FILE_NAME};
 use crate::filesystem::{copy_all, new_dir_replace_if_exists};
 use crate::manifest::{read_manifest, Manifest, PackageType};
 use crate::tar::create_tar_gz;
@@ -28,7 +28,7 @@ pub fn package(manifest_folder: &PathBuf, dst_folder: &PathBuf) -> Result<Packag
     copy_all(
         &manifest_folder,
         &data_temp_folder_path,
-        &["target", ".cargo", ".vscode", &temp_folder_name],
+        &["target", ".cargo", ".vscode", &temp_folder_name, &DEPENDENCIES_FOLDER_NAME],
         &[".env"],
     )?;
 

--- a/noir-libs/src/path.rs
+++ b/noir-libs/src/path.rs
@@ -1,16 +1,4 @@
-use directories::ProjectDirs;
 use std::path::PathBuf;
-
-use crate::config::{COMPANY_NAME, COMPANY_TLD};
-
-/// Gets a cache directory, based on operation system
-/// Linux: /home/user/.cache/noir-libs/
-/// macOS: /Users/user/Library/Application Support/com.walnut.noir-libs/
-/// Windows: C:\Users\Alice\AppData\Roaming\walnut\noir-libs
-pub fn get_cache_dir() -> Option<PathBuf> {
-    ProjectDirs::from(COMPANY_TLD, COMPANY_NAME, env!("CARGO_PKG_NAME"))
-        .map(|proj_dirs| proj_dirs.cache_dir().to_path_buf())
-}
 
 /// Creates a full package name from package name and version
 /// Example: aztec-0.67.0
@@ -41,22 +29,6 @@ pub fn get_package_dir(cache_root: PathBuf, package_name: &str, version: &str) -
 mod tests {
     use super::*;
     use directories::ProjectDirs;
-
-    #[test]
-    fn test_get_cache_dir() {
-        let package_name = env!("CARGO_PKG_NAME");
-        let company_name = "walnut";
-        let company_tld = "dev";
-
-        // Create a mock ProjectDirs instance
-        let proj_dirs = ProjectDirs::from(company_tld, company_name, package_name).unwrap();
-        let cache_dir = proj_dirs.cache_dir().to_path_buf();
-
-        // Call the function and assert the result
-        let result = get_cache_dir();
-        assert!(result.is_some());
-        assert_eq!(result.unwrap(), cache_dir);
-    }
 
     #[test]
     fn test_get_full_package_name() {


### PR DESCRIPTION
This PR introduces given changes:

- dependencies folder is now in the same folder where `Nargo.toml` file.
- dependencies paths in Nargo.toml are now relative e.g. `aztec = { path = ".noir-libs-deps/aztec/0.67.0" }`. This should solve currently the problem of paths: absolute is incorrect, but complex relative path can be also problematic. Dependencies folder on the level of `Nargo.toml` file should be good solution for now.
- added `fetch` command - which downloads all dependencies to a project. The command is dedicated for someone starting with a project where there is Nargo.toml with noir-libs dependencies, but they are not downloaded yet (and nargo will not download them too).